### PR TITLE
LiquidityPenaltyHook documentation simplification, slights renamings and utility functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "docs": "npm run prepare-docs && oz-docs",
-    "docs:watch": "oz-docs watch contracts docs/templates docs/config.js",
+    "docs:watch": "oz-docs watch src docs/templates docs/config.js",
     "prepare-docs": "scripts/prepare-docs.sh"
   },
   "repository": "https://github.com/OpenZeppelin/uniswap-hooks.git",

--- a/src/general/LiquidityPenaltyHook.sol
+++ b/src/general/LiquidityPenaltyHook.sol
@@ -94,8 +94,8 @@ contract LiquidityPenaltyHook is BaseHook {
 
         // If liquidity was added recently within the `blockNumberOffset`, retain the `feesAccrued` in this hook.
         if (_getBlockNumber() - getLastAddedLiquidityBlock(id, positionKey) < blockNumberOffset) {
-            _takeFeesToHook(key, positionKey, feeDelta);
             _updateLastAddedLiquidityBlock(id, positionKey);
+            _takeFeesToHook(key, positionKey, feeDelta);
 
             return (this.afterAddLiquidity.selector, feeDelta);
         }

--- a/src/general/LiquidityPenaltyHook.sol
+++ b/src/general/LiquidityPenaltyHook.sol
@@ -176,10 +176,10 @@ contract LiquidityPenaltyHook is BaseHook {
     function _takeFeesToHook(PoolKey calldata key, bytes32 positionKey, BalanceDelta feeDelta) internal {
         PoolId id = key.toId();
 
+        withheldFeesAccrued[id][positionKey] = withheldFeesAccrued[id][positionKey] + feeDelta;
+
         key.currency0.take(poolManager, address(this), uint256(uint128(feeDelta.amount0())), true);
         key.currency1.take(poolManager, address(this), uint256(uint128(feeDelta.amount1())), true);
-
-        withheldFeesAccrued[id][positionKey] = withheldFeesAccrued[id][positionKey] + feeDelta;
     }
 
     /**
@@ -190,6 +190,9 @@ contract LiquidityPenaltyHook is BaseHook {
 
         withheldFees = getWithheldFees(id, positionKey);
 
+        // Reset the `withheldFeesAccrued`.
+        withheldFeesAccrued[id][positionKey] = BalanceDeltaLibrary.ZERO_DELTA;
+
         // Settle the `withheldFeesAccrued` for the liquidity position.
         if (withheldFees.amount0() > 0) {
             key.currency0.settle(poolManager, address(this), uint256(uint128(withheldFees.amount0())), true);
@@ -197,9 +200,6 @@ contract LiquidityPenaltyHook is BaseHook {
         if (withheldFees.amount1() > 0) {
             key.currency1.settle(poolManager, address(this), uint256(uint128(withheldFees.amount1())), true);
         }
-
-        // Reset the `withheldFeesAccrued`.
-        withheldFeesAccrued[id][positionKey] = BalanceDeltaLibrary.ZERO_DELTA;
     }
 
     /**

--- a/src/general/LiquidityPenaltyHook.sol
+++ b/src/general/LiquidityPenaltyHook.sol
@@ -21,7 +21,7 @@ import {ModifyLiquidityParams} from "v4-core/src/types/PoolOperation.sol";
 import {BalanceDelta, BalanceDeltaLibrary, toBalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
 
 /**
- * @dev Just in time (JIT) liquidity provisioning resistant hook.
+ * @dev Just-in-Time (JIT) liquidity provisioning resistant hook.
  * 
  * This hook disincentivizes JIT attacks by penalizing LP fee collection during `afterRemoveLiquidity`,
  * and disabling it during `afterAddLiquidity` if liquidity was recently added to the position.
@@ -51,8 +51,9 @@ contract LiquidityPenaltyHook is BaseHook {
     uint256 public constant MIN_BLOCK_NUMBER_OFFSET = 1;
 
     /**
-     * @dev The `blockNumberOffset` is the number of blocks since `lastAddedLiquidityBlock` during which the JIT penalty
-     * is applied and fees are donated to the pool LPs in range. See {_calculateLiquidityPenalty} for penalty calculation.
+     * @dev The minimum time window (in blocks) that must pass after adding liquidity before it can be 
+     * removed without penalty. During this period, JIT attacks are deterred through fee withholding 
+     * and penalties. Higher values provide stronger JIT protection but may discourage legitimate LPs.
      */
     uint256 private immutable blockNumberOffset;
 


### PR DESCRIPTION
Attempt to simplify documentation with the style of [OpenZeppelin vanilla contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) aiming to improve readability through our [documentation engine output](https://docs.openzeppelin.com/uniswap-hooks/1.x/)