### PR TITLE
Refactor AntisandwichHook tests

### DIFF
--- a/src/general/AntiSandwichHook.sol
+++ b/src/general/AntiSandwichHook.sol
@@ -178,6 +178,7 @@ contract AntiSandwichHook is BaseDynamicAfterFee {
     function _getTargetOutput(address, PoolKey calldata key, SwapParams calldata params, bytes calldata)
         internal
         override
+        virtual
         returns (uint256 targetOutput, bool applyTargetOutput)
     {
         if (params.zeroForOne) {
@@ -223,7 +224,7 @@ contract AntiSandwichHook is BaseDynamicAfterFee {
         BalanceDelta,
         uint256,
         uint256 feeAmount
-    ) internal override {
+    ) internal virtual override {
         Currency unspecified = (params.amountSpecified < 0 == params.zeroForOne) ? (key.currency1) : (key.currency0);
         (uint256 amount0, uint256 amount1) = unspecified == key.currency0
             ? (uint256(uint128(feeAmount)), uint256(0))

--- a/src/general/AntiSandwichHook.sol
+++ b/src/general/AntiSandwichHook.sol
@@ -20,6 +20,7 @@ import {BeforeSwapDelta} from "v4-core/src/types/BeforeSwapDelta.sol";
 import {Slot0} from "v4-core/src/types/Slot0.sol";
 import {Currency} from "v4-core/src/types/Currency.sol";
 import {SwapParams} from "v4-core/src/types/PoolOperation.sol";
+
 /**
  * @dev Sandwich-resistant hook, based on
  * https://github.com/cairoeth/sandwich-resistant-hook/blob/master/src/srHook.sol[this]

--- a/test/general/AntiSandwichHook.t.sol
+++ b/test/general/AntiSandwichHook.t.sol
@@ -18,14 +18,12 @@ import {console} from "forge-std/console.sol";
 import {BalanceDeltaAssertions} from "../utils/BalanceDeltaAssertions.sol";
 
 contract AntiSandwichHookTest is HookTest, BalanceDeltaAssertions {
-    using SignedMath for int256;
-
     AntiSandwichHook hook;
     PoolKey noHookKey;
 
     BaseDynamicFeeMock dynamicFeesHooks;
 
-    // @dev expected values for pools with 1e18 liquidity. 
+    // @dev expected values for pools with 1e18 liquidity.
     int128 constant SWAP_AMOUNT_1e15 = 1e15;
     int128 constant SWAP_RESULT_1e15 = 999000999000999;
 
@@ -67,7 +65,9 @@ contract AntiSandwichHookTest is HookTest, BalanceDeltaAssertions {
     }
 
     function test_swap_zeroForOne_exactInput_backrunExactInput() public {
-        // front run, first attacker transaction, exactInput
+        // front run, exactInput
+        // - sends token0 (SWAP_AMOUNT)
+        // - receives token1 (unknown amount)
         BalanceDelta deltaAttack1WithKey = swap(key, true, -SWAP_AMOUNT_1e15, ZERO_BYTES);
         BalanceDelta deltaAttack1WithoutKey = swap(noHookKey, true, -SWAP_AMOUNT_1e15, ZERO_BYTES);
 
@@ -82,32 +82,43 @@ contract AntiSandwichHookTest is HookTest, BalanceDeltaAssertions {
 
         assertTrue(deltaUserWithKey == deltaUserWithoutKey, "both pools should give the same output");
 
-        // back run, second attacker transaction, exactInput
+        // back run, exactInput
+        // - sends token1 (amount received in front run)
+        // - receives token0 (unknown amount)
+        // To make a profit, the ataccker must receive more token0 than he sent in the frontrun.
+        console.log("deltaAttack1WithKey.amount1()", int256(deltaAttack1WithKey.amount1()));
         BalanceDelta deltaAttack2WithKey = swap(key, false, -int256(deltaAttack1WithKey.amount1()), ZERO_BYTES);
         BalanceDelta deltaAttack2WithoutKey = swap(noHookKey, false, -int256(deltaAttack1WithKey.amount1()), ZERO_BYTES);
 
-        assertGt(
-            deltaAttack2WithoutKey.amount0(),
-            -deltaAttack1WithoutKey.amount0(),
-            "attacker should make a profit in the unhooked pool"
-        );
+        console.log("deltaAttack2WithKey.amount0()", int256(deltaAttack2WithKey.amount0()));
+        console.log("deltaAttack1WithKey.amount0()", int256(deltaAttack1WithKey.amount0()));
+
+        // If the attacker receives equal or less token0 than he sent in the frontrun, he loses money.
         assertLe(
             deltaAttack2WithKey.amount0(),
             -deltaAttack1WithKey.amount0(),
             "attacker should lose money in the hooked pool"
         );
 
+        assertGt(
+            deltaAttack2WithoutKey.amount0(),
+            -deltaAttack1WithoutKey.amount0(),
+            "attacker should make a profit in the unhooked pool"
+        );
+
         // next block
         vm.roll(block.number + 1);
 
-        BalanceDelta deltaResetState = swap(key, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
-        BalanceDelta deltaNextBlock = swap(noHookKey, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
+        BalanceDelta deltaResetWithKey = swap(key, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
+        BalanceDelta deltaResetWithoutKey = swap(noHookKey, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
 
-        assertEq(deltaResetState.amount0(), deltaNextBlock.amount0(), "hook should reset state");
+        assertEq(deltaResetWithKey.amount0(), deltaResetWithoutKey.amount0(), "hook should reset state");
     }
 
-    function test_swap_zeroForOne_exactInput_backRunExactOutput() public {
-        // front run, first attacker transaction, exactInput
+    function test_swap_zeroForOne_exactInput_backrunExactOutput() public {
+        // front run, exactInput
+        // - sends token0 (SWAP_AMOUNT)
+        // - receives token1 (unknown amount)
         BalanceDelta deltaAttack1WithKey = swap(key, true, -SWAP_AMOUNT_1e15, ZERO_BYTES);
         BalanceDelta deltaAttack1WithoutKey = swap(noHookKey, true, -SWAP_AMOUNT_1e15, ZERO_BYTES);
 
@@ -122,32 +133,43 @@ contract AntiSandwichHookTest is HookTest, BalanceDeltaAssertions {
 
         assertTrue(deltaUserWithKey == deltaUserWithoutKey, "both pools should give the same output");
 
-        // back run, second attacker transaction, exactOutput
+        // back run, exactOutput
+        // - sends token1 (unknown amount)
+        // - receives token0 (amount sent in front run)
+        // To make a profit, the attacker must send less token1 than he received in the frontrun.
+        console.log("deltaAttack1WithKey.amount0()", int256(deltaAttack1WithKey.amount0()));
         BalanceDelta deltaAttack2WithKey = swap(key, false, -int256(deltaAttack1WithKey.amount0()), ZERO_BYTES);
         BalanceDelta deltaAttack2WithoutKey = swap(noHookKey, false, -int256(deltaAttack1WithKey.amount0()), ZERO_BYTES);
 
-        assertGt(
-            deltaAttack2WithoutKey.amount0(),
-            -deltaAttack1WithoutKey.amount0(),
-            "attacker should make a profit in the unhooked pool"
-        );
-        assertLe(
-            deltaAttack2WithKey.amount0(),
-            -deltaAttack1WithKey.amount0(),
+        console.log("deltaAttack2WithKey.amount1()", int256(deltaAttack2WithKey.amount1()));
+        console.log("deltaAttack1WithKey.amount1()", int256(deltaAttack1WithKey.amount1()));
+
+        // If the attacker gives more or equal token1 than he received in the frontrun, he loses money.
+        assertGe(
+            -deltaAttack2WithKey.amount1(),
+            deltaAttack1WithKey.amount1(),
             "attacker should lose money in the hooked pool"
+        );
+
+        assertLt(
+            -deltaAttack2WithoutKey.amount1(),
+            deltaAttack1WithoutKey.amount1(),
+            "attacker should make a profit in the unhooked pool"
         );
 
         // next block
         vm.roll(block.number + 1);
 
-        BalanceDelta deltaResetState = swap(key, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
-        BalanceDelta deltaNextBlock = swap(noHookKey, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
+        BalanceDelta deltaResetWithKey = swap(key, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
+        BalanceDelta deltaResetWithoutKey = swap(noHookKey, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
 
-        assertEq(deltaResetState.amount0(), deltaNextBlock.amount0(), "hook should reset state");
+        assertEq(deltaResetWithKey.amount0(), deltaResetWithoutKey.amount0(), "hook should reset state");
     }
 
-    function test_swap_zeroForOne_exactOutput_backRunExactInput() public {
-        // front run, first attacker transaction, exactOutput
+    function test_swap_zeroForOne_exactOutput_backrunExactInput() public {
+        // front run, exactOutput
+        // - gives token1 (unknown amount)
+        // - receives token0 (SWAP_AMOUNT)
         BalanceDelta deltaAttack1WithKey = swap(key, true, SWAP_AMOUNT_1e15, ZERO_BYTES);
         BalanceDelta deltaAttack1WithoutKey = swap(noHookKey, true, SWAP_AMOUNT_1e15, ZERO_BYTES);
 
@@ -162,32 +184,43 @@ contract AntiSandwichHookTest is HookTest, BalanceDeltaAssertions {
 
         assertTrue(deltaUserWithKey == deltaUserWithoutKey, "both pools should give the same output");
 
-        // back run, second attacker transaction, exactInput
-        BalanceDelta deltaAttack2WithKey = swap(key, false, -int256(deltaAttack1WithKey.amount0()), ZERO_BYTES);
-        BalanceDelta deltaAttack2WithoutKey = swap(noHookKey, false, -int256(deltaAttack1WithKey.amount0()), ZERO_BYTES);
+        // back run, exactInput, gives token1 receives token0
+        // - gives token0 (amount received in front run)
+        // - receives token1 (unknown amount)
+        // To make a profit, the attacker must receive more token1 than he gave in the frontrun.
+        console.log("deltaAttack1WithKey.amount0()", int256(deltaAttack1WithKey.amount0()));
+        BalanceDelta deltaAttack2WithKey = swap(key, false, int256(deltaAttack1WithKey.amount0()), ZERO_BYTES);
+        BalanceDelta deltaAttack2WithoutKey = swap(noHookKey, false, int256(deltaAttack1WithKey.amount0()), ZERO_BYTES);
+
+        console.log("deltaAttack2WithKey.amount1()", int256(deltaAttack2WithKey.amount1()));
+        console.log("deltaAttack1WithKey.amount1()", int256(deltaAttack1WithKey.amount1()));
+
+        // If the attacker receives equal or less token1 than he gave in the frontrun, he loses money.
+        assertLe(
+            -deltaAttack2WithKey.amount1(),
+            deltaAttack1WithKey.amount1(),
+            "attacker should lose money in the hooked pool"
+        );
 
         assertGt(
-            deltaAttack2WithoutKey.amount0(),
-            -deltaAttack1WithoutKey.amount0(),
+            -deltaAttack2WithoutKey.amount1(),
+            deltaAttack1WithoutKey.amount1(),
             "attacker should make a profit in the unhooked pool"
-        );
-        assertLe(
-            deltaAttack2WithKey.amount0(),
-            -deltaAttack1WithKey.amount0(),
-            "attacker should lose money in the hooked pool"
         );
 
         // next block
         vm.roll(block.number + 1);
 
-        BalanceDelta deltaResetState = swap(key, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
-        BalanceDelta deltaNextBlock = swap(noHookKey, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
+        BalanceDelta deltaResetWithKey = swap(key, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
+        BalanceDelta deltaResetWithoutKey = swap(noHookKey, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
 
-        assertEq(deltaResetState.amount0(), deltaNextBlock.amount0(), "hook should reset state");
+        assertEq(deltaResetWithKey.amount0(), deltaResetWithoutKey.amount0(), "hook should reset state");
     }
 
-    function test_swap_zeroForOne_exactOutput_frontRunExactOutput() public {
-        // front run, first attacker transaction, exactOutput
+    function test_swap_zeroForOne_exactOutput_backrunExactOutput() public {
+        // front run, exactOutput
+        // - sends token0 (unknown amount)
+        // - receives token1 (SWAP_AMOUNT)
         BalanceDelta deltaAttack1WithKey = swap(key, true, SWAP_AMOUNT_1e15, ZERO_BYTES);
         BalanceDelta deltaAttack1WithoutKey = swap(noHookKey, true, SWAP_AMOUNT_1e15, ZERO_BYTES);
 
@@ -202,28 +235,33 @@ contract AntiSandwichHookTest is HookTest, BalanceDeltaAssertions {
 
         assertTrue(deltaUserWithKey == deltaUserWithoutKey, "both pools should give the same output");
 
-        // back run, second attacker transaction, exactOutput
-        BalanceDelta deltaAttack2WithKey = swap(key, false, -int256(deltaAttack1WithKey.amount1()), ZERO_BYTES);
-        BalanceDelta deltaAttack2WithoutKey = swap(noHookKey, false, -int256(deltaAttack1WithKey.amount1()), ZERO_BYTES);
+        // back run, exactOutput
+        // - sends token1 (unknown amount)
+        // - receives token0 (amount of token0 sent in front run)
+        // To make a profit, the attacker must send less token1 than he received in the frontrun.
+        BalanceDelta deltaAttack2WithKey = swap(key, false, -int256(deltaAttack1WithKey.amount0()), ZERO_BYTES);
+        BalanceDelta deltaAttack2WithoutKey = swap(noHookKey, false, -int256(deltaAttack1WithKey.amount0()), ZERO_BYTES);
 
-        assertGt(
-            deltaAttack2WithoutKey.amount0(),
-            -deltaAttack1WithoutKey.amount0(),
-            "attacker should make a profit in the unhooked pool"
-        );
-        assertLe(
-            deltaAttack2WithKey.amount0(),
-            -deltaAttack1WithKey.amount0(),
+        // If the attacker sends more or equal token1 than he received in the frontrun, he loses money.
+        assertGe(
+            -deltaAttack2WithKey.amount1(),
+            deltaAttack1WithKey.amount1(),
             "attacker should lose money in the hooked pool"
+        );
+
+        assertLt(
+            -deltaAttack2WithoutKey.amount1(),
+            deltaAttack1WithoutKey.amount1(),
+            "attacker should make a profit in the unhooked pool"
         );
 
         // next block
         vm.roll(block.number + 1);
 
-        BalanceDelta deltaResetState = swap(key, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
-        BalanceDelta deltaNextBlock = swap(noHookKey, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
+        BalanceDelta deltaResetWithKey = swap(key, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
+        BalanceDelta deltaResetWithoutKey = swap(noHookKey, false, -SWAP_AMOUNT_1e15, ZERO_BYTES);
 
-        assertEq(deltaResetState.amount0(), deltaNextBlock.amount0(), "hook should reset state");
+        assertEq(deltaResetWithKey.amount0(), deltaResetWithoutKey.amount0(), "hook should reset state");
     }
 
     /// @notice Unit test for a failed sandwich attack using the hook.

--- a/test/general/LiquidityPenaltyHook.t.sol
+++ b/test/general/LiquidityPenaltyHook.t.sol
@@ -19,8 +19,9 @@ import {PoolSwapTest} from "v4-core/src/test/PoolSwapTest.sol";
 import {HookTest} from "test/utils/HookTest.sol";
 import {toBalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
 import {CustomRevert} from "v4-core/src/libraries/CustomRevert.sol";
+import {BalanceDeltaAssertions} from "../utils/BalanceDeltaAssertions.sol";
 
-contract LiquidityPenaltyHookTest is HookTest {
+contract LiquidityPenaltyHookTest is HookTest, BalanceDeltaAssertions {
     LiquidityPenaltyHook hook;
     PoolKey noHookKey;
     uint24 fee = 1000; // 0.1%

--- a/test/utils/BalanceDeltaAssertions.sol
+++ b/test/utils/BalanceDeltaAssertions.sol
@@ -72,4 +72,30 @@ contract BalanceDeltaAssertions is Test {
         bool amount0Gt = BalanceDeltaLibrary.amount0(delta1) > BalanceDeltaLibrary.amount0(delta2);
         assertTrue(amount1Gt || amount0Gt, err);
     }
+
+    // @dev Asserts that delta1 is less than delta2 for both amount0 and amount1
+    function assertLt(BalanceDelta delta1, BalanceDelta delta2) internal pure {
+        assertLt(BalanceDeltaLibrary.amount1(delta1), BalanceDeltaLibrary.amount1(delta2));
+        assertLt(BalanceDeltaLibrary.amount0(delta1), BalanceDeltaLibrary.amount0(delta2));
+    }
+
+    // @dev Asserts that delta1 is less than delta2 for both amount0 and amount1 with a custom error message
+    function assertLt(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal pure {
+        assertLt(BalanceDeltaLibrary.amount1(delta1), BalanceDeltaLibrary.amount1(delta2), err);
+        assertLt(BalanceDeltaLibrary.amount0(delta1), BalanceDeltaLibrary.amount0(delta2), err);
+    }
+
+    // @dev Asserts that delta1 is less than delta2 for either amount0 or amount1
+    function assertEitherLt(BalanceDelta delta1, BalanceDelta delta2) internal pure {
+        bool amount1Lt = BalanceDeltaLibrary.amount1(delta1) < BalanceDeltaLibrary.amount1(delta2);
+        bool amount0Lt = BalanceDeltaLibrary.amount0(delta1) < BalanceDeltaLibrary.amount0(delta2);
+        assertTrue(amount1Lt || amount0Lt);
+    }
+
+    // @dev Asserts that delta1 is less than delta2 for either amount0 or amount1 with a custom error message
+    function assertEitherLt(BalanceDelta delta1, BalanceDelta delta2, string memory err) internal pure {
+        bool amount1Lt = BalanceDeltaLibrary.amount1(delta1) < BalanceDeltaLibrary.amount1(delta2);
+        bool amount0Lt = BalanceDeltaLibrary.amount0(delta1) < BalanceDeltaLibrary.amount0(delta2);
+        assertTrue(amount1Lt || amount0Lt, err);
+    }
 }

--- a/test/utils/HookTest.sol
+++ b/test/utils/HookTest.sol
@@ -15,10 +15,9 @@ import {FixedPoint128} from "v4-core/src/libraries/FixedPoint128.sol";
 import {PoolSwapTest} from "v4-core/src/test/PoolSwapTest.sol";
 import {SwapParams} from "v4-core/src/types/PoolOperation.sol";
 import {IPoolManagerEvents} from "./IPoolManagerEvents.sol";
-import {BalanceDeltaAssertions} from "./BalanceDeltaAssertions.sol";
 
 // @dev Set of utilities to test Hooks.
-contract HookTest is Test, Deployers, IPoolManagerEvents, BalanceDeltaAssertions {
+contract HookTest is Test, Deployers, IPoolManagerEvents {
     // @dev Calculate the current `feesAccrued` for a given position.
     function calculateFees(
         IPoolManager manager,
@@ -67,27 +66,10 @@ contract HookTest is Test, Deployers, IPoolManagerEvents, BalanceDeltaAssertions
         return modifyLiquidityRouter.modifyLiquidity(poolKey, modifyLiquidityParams, "");
     }
 
-    // @dev Swap tokens in a given pool.
-    function swap(PoolKey memory poolKey, bool zeroForOne, int256 amountSpecified, uint160 sqrtPriceLimitX96)
-        internal
-        returns (BalanceDelta)
-    {
-        PoolSwapTest.TestSettings memory testSettings =
-            PoolSwapTest.TestSettings({takeClaims: false, settleUsingBurn: false});
-        SwapParams memory swapParams =
-            SwapParams({zeroForOne: zeroForOne, amountSpecified: amountSpecified, sqrtPriceLimitX96: sqrtPriceLimitX96});
-        return swapRouter.swap(poolKey, swapParams, testSettings, "");
-    }
-
     // @dev Swaps all combinations of `zeroForOne` (true/false) and `amountSpecified` (+,-) in a given pool.
     function swapAllCombinations(PoolKey memory poolKey, uint256 amount) internal {
         for (uint256 i = 0; i < 4; i++) {
-            swap(
-                poolKey,
-                i < 2 ? false : true,
-                i % 2 == 0 ? -int256(amount) : int256(amount),
-                i < 2 ? MAX_PRICE_LIMIT : MIN_PRICE_LIMIT
-            );
+            swap(poolKey, i < 2 ? false : true, i % 2 == 0 ? -int256(amount) : int256(amount), ZERO_BYTES);
         }
     }
 }


### PR DESCRIPTION
- Makes functions virtual for inheritance customization. https://github.com/OpenZeppelin/uniswap-hooks/pull/70#discussion_r2146024279
- Removes duplicated for cycle code in `beforeSwap` https://github.com/OpenZeppelin/uniswap-hooks/pull/70#discussion_r2145914872
- Refactors tests for simplicity using `swap` from UniswapV4 testing utility `Deployers.sol` and BalanceDeltaAssertions.
- Fix some assertions that were checking incorrect variables https://github.com/OpenZeppelin/uniswap-hooks/pull/70#discussion_r2148847316
- Removes dependency of foundry in `HookTest.sol` by avoiding inheritance in it from `BalanceDeltaAssertions`, that currently is foundry dependant.